### PR TITLE
出力されるレイヤー画像のファイル名に連番を付けるオプション等

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gdnative = "0.10.0"
-psd = "0.3.1"
+godot = { git = "https://github.com/godot-rust/gdext", branch = "master" }
+psd = "0.3.5"
 image = "0.24.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -20,6 +20,3 @@ crate-type = ["cdylib"]
 
 [target.x86_64-pc-windows-gnu]
 linker = "x86_64-w64-mingw32-gcc"
-
-[patch.crates-io]
-psd = { git = 'https://github.com/folt-a/psd', branch = 'master' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-godot = { git = "https://github.com/godot-rust/gdext", branch = "master" }
+godot = { git = "https://github.com/godot-rust/gdext", branch = "master" , features = ["api-4-2-2"] }
 psd = "0.3.5"
 image = "0.24.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,18 +173,18 @@ impl PsdDataExport {
         }
 
         // ドキュメント全体のレイヤー等名の重複チェック
-        if Self::get_export_option_value(export_options, "append_suffix_by_order", false) {
+        if !Self::get_export_option_value(export_options, "append_suffix_by_order", false) {
             let mut doc_member_names : std::collections::HashSet<String> = std::collections::HashSet::new();
             for group in groups.iter() {
                 let group_name_string : String = group.name().to_string();
                 if !doc_member_names.insert(group_name_string) { // insert で存在確認する
-                    panic!("Duplicated name of Layer or Group in a document is not allowed unless append_suffix_by_order is enabled."); 
+                    panic!("Duplicated name of Layer or Group in a document is not allowed unless append_suffix_by_order is enabled. duplicated name: {}", group.name().to_string()); 
                 }
             }
             for layer in layers.iter() {
                 let layer_name_string : String = layer.name().to_string();
                 if !doc_member_names.insert(layer_name_string) { // insert で存在確認する
-                    panic!("Duplicated name of Layer or Group in a document is not allowed unless append_suffix_by_order is enabled."); 
+                    panic!("Duplicated name of Layer or Group in a document is not allowed unless append_suffix_by_order is enabled. duplicated name: {}", layer.name().to_string()); 
                 } 
             }
         }
@@ -197,7 +197,7 @@ impl PsdDataExport {
             let parent_id_as_usize = usize::try_from(parent_id).unwrap();
             let group_name_string : String = group.name().to_string();
             if !groups_member_names[parent_id_as_usize].insert(group_name_string) { // insert で存在確認する
-                panic!("Duplicated name of Layer or Group in a same group is not allowed."); 
+                panic!("Duplicated name of Layer or Group in a same group is not allowed. duplicated name: {}", group.name().to_string()); 
             }
         }
         for layer in layers.iter() {
@@ -205,7 +205,7 @@ impl PsdDataExport {
             let parent_id_as_usize = usize::try_from(parent_id).unwrap();
             let layer_name_string : String = layer.name().to_string();
             if !groups_member_names[parent_id_as_usize].insert(layer_name_string) { // insert で存在確認する
-                panic!("Duplicated name of Layer or Group in a same group is not allowed."); 
+                panic!("Duplicated name of Layer or Group in a same group is not allowed. duplicated name: {}", layer.name().to_string()); 
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 // use gdnative::api::{Directory, File};
 use godot::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::fs;
 use std::fs::{File};
 use std::io::Write;
@@ -49,7 +50,7 @@ struct PsdDataExport {
 impl PsdDataExport {
 
     #[func]
-    fn execute(&self) {
+    fn execute(&self, export_options : godot::builtin::Dictionary) {
         let dir_path = GString::to_string(&self.psd_dir);
         let mut psd_files: Vec<String> = Vec::new();
 
@@ -57,7 +58,7 @@ impl PsdDataExport {
         self.recursive_psd_files(dir_path, psd_files.as_mut());
 
         for psd_file_path in psd_files {
-            self.export(psd_file_path.as_str());
+            self.export(psd_file_path.as_str(), &export_options);
         }
     }
 
@@ -97,7 +98,7 @@ impl PsdDataExport {
         }
     }
 
-    fn export(&self, file_name: &str) {
+    fn export(&self, file_name: &str, export_options : &Dictionary) {
         godot_print!("{}", file_name);
 
         let psd_dir_path = GString::to_string(&self.psd_dir);
@@ -111,12 +112,13 @@ impl PsdDataExport {
         let mut groups_json: Vec<Group> = Vec::new();
         let mut layers_json: Vec<Layer> = Vec::new();
 
-        let groups: Vec<&PsdGroup> = psd.group_ids_in_order()
+        let mut groups: Vec<&PsdGroup> = psd.group_ids_in_order()
             .iter()
             .map(|x| { psd.groups().get(x).unwrap() })
             .collect();
         // groups.sort_by_key(|x1| { x1.order_id() });
         // groups.sort_by_key(|x1| { x1.parent_id() });
+        groups.sort_by_key(|x1| { x1.id() });
 
         for (i, group) in groups.iter().enumerate() {
             // println!("{}", i);
@@ -170,6 +172,43 @@ impl PsdDataExport {
             layers_json.push(layer_model);
         }
 
+        // ドキュメント全体のレイヤー等名の重複チェック
+        if Self::get_export_option_value(export_options, "append_suffix_by_order", false) {
+            let mut doc_member_names : std::collections::HashSet<String> = std::collections::HashSet::new();
+            for group in groups.iter() {
+                let group_name_string : String = group.name().to_string();
+                if !doc_member_names.insert(group_name_string) { // insert で存在確認する
+                    panic!("Duplicated name of Layer or Group in a document is not allowed unless append_suffix_by_order is enabled."); 
+                }
+            }
+            for layer in layers.iter() {
+                let layer_name_string : String = layer.name().to_string();
+                if !doc_member_names.insert(layer_name_string) { // insert で存在確認する
+                    panic!("Duplicated name of Layer or Group in a document is not allowed unless append_suffix_by_order is enabled."); 
+                } 
+            }
+        }
+
+        // グループごとのレイヤー名の重複チェック
+        let mut groups_member_names : Vec<std::collections::HashSet<String>> = Vec::new();
+        groups_member_names.resize(groups.len()+1, HashSet::new());
+        for group in groups.iter() {
+            let parent_id = group.parent_id().unwrap_or(0u32);
+            let parent_id_as_usize = usize::try_from(parent_id).unwrap();
+            let group_name_string : String = group.name().to_string();
+            if !groups_member_names[parent_id_as_usize].insert(group_name_string) { // insert で存在確認する
+                panic!("Duplicated name of Layer or Group in a same group is not allowed."); 
+            }
+        }
+        for layer in layers.iter() {
+            let parent_id = layer.parent_id().unwrap_or(0u32);
+            let parent_id_as_usize = usize::try_from(parent_id).unwrap();
+            let layer_name_string : String = layer.name().to_string();
+            if !groups_member_names[parent_id_as_usize].insert(layer_name_string) { // insert で存在確認する
+                panic!("Duplicated name of Layer or Group in a same group is not allowed."); 
+            }
+        }
+
         // 出力先PNGのディレクトリ作成
         let export_dir_path = std::path::Path::new(&export_dir_path);
         let export_dir_path = export_dir_path.join(file_name);
@@ -192,7 +231,7 @@ impl PsdDataExport {
 
         // println!("{}", "--------------------");
 
-        for layer in psd.layers().iter() {
+        for (i, layer) in psd.layers().iter().enumerate() {
             let layer_name: String = layer.name().to_string();
             let psd_width: u32 = psd.width();
             let psd_height: u32 = psd.height();
@@ -205,7 +244,13 @@ impl PsdDataExport {
             // PSD全体からレイヤー部分のみクロップする
             let layer_image = image::imageops::crop(&mut img, layer_x, layer_y, layer_width, layer_height);
             let extension = GString::to_string(&self.image_extension);
-            let export_image_path = &export_dir_path.join(layer_name + "." + GString::to_string(&self.image_extension).as_str());
+            let export_image_path =
+                if Self::get_export_option_value(export_options, "append_suffix_by_order", false) { 
+                    export_dir_path.join(layer_name + "_" + &(format!("{:0>4}", i.to_string())) + "." + GString::to_string(&self.image_extension).as_str())
+                } else { 
+                    export_dir_path.join(layer_name + "." + GString::to_string(&self.image_extension).as_str())
+                };
+
             match &*extension {
                 "png" => {
                     layer_image
@@ -255,6 +300,12 @@ impl PsdDataExport {
                 _ => panic!(),
             }
         }
+    }
+
+    fn get_export_option_value<T>(export_options : &Dictionary, key_str : &str, default : T) -> T where T : ToGodot + FromGodot {
+        let Some(option_value_variant) = export_options.get(StringName::from(key_str)) else { return default };
+
+        option_value_variant.try_to().unwrap_or(default)
     }
 }
 
@@ -347,10 +398,11 @@ struct LibEntry;
 unsafe impl ExtensionLibrary for LibEntry {
     fn min_level() -> InitLevel { InitLevel::Core }
 
+    #[allow(clippy::single_match)] // 将来的にInitLevel::Core以外のInitLevel::Coreで何かする可能性を考慮している
     fn on_level_init(level: InitLevel){
         match level {
-            InitLevel::Core => {init_panic_hook()},
-            _ => {}
+            InitLevel::Core => { init_panic_hook(); }, // FIXME: ちゃんと効いてるかわからない 多分効いてない
+            _ => {} // 何もしない
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,8 @@
 use godot::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
-use std::fs;
+use std::fmt::Display;
+use std::fs::{self};
 use std::fs::{File};
 use std::io::Write;
 use std::io::{BufWriter};
@@ -58,7 +59,14 @@ impl PsdDataExport {
         self.recursive_psd_files(dir_path, psd_files.as_mut());
 
         for psd_file_path in psd_files {
-            self.export(psd_file_path.as_str(), &export_options);
+            match self.export(psd_file_path.as_str(), &export_options) {
+                Ok(_) => {
+                    // do nothing
+                },
+                Err(err) => {
+                    godot::global::push_error(&[err.to_string().to_variant()]);
+                }
+            }
         }
     }
 
@@ -98,7 +106,7 @@ impl PsdDataExport {
         }
     }
 
-    fn export(&self, file_name: &str, export_options : &Dictionary) {
+    fn export(&self, file_name: &str, export_options : &Dictionary) -> Result<(), PsdExportError> {
         godot_print!("{}", file_name);
 
         let psd_dir_path = GString::to_string(&self.psd_dir);
@@ -178,13 +186,25 @@ impl PsdDataExport {
             for group in groups.iter() {
                 let group_name_string : String = group.name().to_string();
                 if !doc_member_names.insert(group_name_string) { // insert で存在確認する
-                    panic!("Duplicated name of Layer or Group in a document is not allowed unless append_suffix_by_order is enabled. duplicated name: {}", group.name().to_string()); 
+                    return Err(PsdExportError::new(
+                        PsdExportErrorKind::new_duplication(
+                            group.name().to_string(), 
+                            DuplicationScope::Document
+                        ),
+                        file_name.to_owned(), 
+                    ));
                 }
             }
             for layer in layers.iter() {
                 let layer_name_string : String = layer.name().to_string();
                 if !doc_member_names.insert(layer_name_string) { // insert で存在確認する
-                    panic!("Duplicated name of Layer or Group in a document is not allowed unless append_suffix_by_order is enabled. duplicated name: {}", layer.name().to_string()); 
+                    return Err(PsdExportError::new(
+                        PsdExportErrorKind::new_duplication(
+                            layer.name().to_string(), 
+                            DuplicationScope::Document
+                        ),
+                        file_name.to_owned(), 
+                    ));
                 } 
             }
         }
@@ -197,7 +217,14 @@ impl PsdDataExport {
             let parent_id_as_usize = usize::try_from(parent_id).unwrap();
             let group_name_string : String = group.name().to_string();
             if !groups_member_names[parent_id_as_usize].insert(group_name_string) { // insert で存在確認する
-                panic!("Duplicated name of Layer or Group in a same group is not allowed. duplicated name: {}", group.name().to_string()); 
+                return Err(PsdExportError::new(
+                    PsdExportErrorKind::new_duplication(
+                        group.name().to_string(), 
+                        DuplicationScope::Group
+                    ),
+                    file_name.to_owned(), 
+                ));
+                // panic!("Duplicated name of Layer or Group in a same group is not allowed. duplicated name: {}", group.name().to_string()); 
             }
         }
         for layer in layers.iter() {
@@ -205,7 +232,14 @@ impl PsdDataExport {
             let parent_id_as_usize = usize::try_from(parent_id).unwrap();
             let layer_name_string : String = layer.name().to_string();
             if !groups_member_names[parent_id_as_usize].insert(layer_name_string) { // insert で存在確認する
-                panic!("Duplicated name of Layer or Group in a same group is not allowed. duplicated name: {}", layer.name().to_string()); 
+                return Err(PsdExportError::new(
+                    PsdExportErrorKind::new_duplication(
+                        layer.name().to_string(), 
+                        DuplicationScope::Group
+                    ),
+                    file_name.to_owned(), 
+                ));
+                // panic!("Duplicated name of Layer or Group in a same group is not allowed. duplicated name: {}", layer.name().to_string()); 
             }
         }
 
@@ -300,6 +334,8 @@ impl PsdDataExport {
                 _ => panic!(),
             }
         }
+
+        Ok(())
     }
 
     fn get_export_option_value<T>(export_options : &Dictionary, key_str : &str, default : T) -> T where T : ToGodot + FromGodot {
@@ -390,6 +426,58 @@ struct Layer {
     blending_mode: u8,
     order_id: i32,
 }
+
+#[derive(Debug)]
+struct PsdExportError {
+    kind : PsdExportErrorKind,
+    psd_name : String,
+}
+
+#[derive(Debug)]
+enum PsdExportErrorKind {
+    NameDuplication(NameDuplicationError)
+}
+
+#[derive(Debug)]
+struct NameDuplicationError {
+    duplicated_element_name : String,
+    scope : DuplicationScope,
+}
+
+#[derive(Debug)]
+enum DuplicationScope { Document, Group }
+
+impl std::error::Error for PsdExportError {}
+
+impl Display for PsdExportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.kind {
+            PsdExportErrorKind::NameDuplication(error) => {
+                match error.scope {
+                    DuplicationScope::Document => {
+                        f.write_str(format!("Duplicated name of Layer or Group in a document is not allowed unless append_suffix_by_order is enabled. duplicated name: {}, psd_name: {}", error.duplicated_element_name, self.psd_name).as_str())
+                    },
+                    DuplicationScope::Group => {
+                        f.write_str(format!("Duplicated name of Layer or Group in a same group is not allowed. duplicated name: {}, psd_name: {}", error.duplicated_element_name, self.psd_name).as_str())
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl PsdExportError {
+    fn new(kind : PsdExportErrorKind, psd_name : String) -> PsdExportError {
+        return PsdExportError {kind, psd_name};
+    }
+}
+
+impl PsdExportErrorKind {
+    fn new_duplication(duplicated_element_name : String, scope : DuplicationScope) -> PsdExportErrorKind {
+        return Self::NameDuplication(NameDuplicationError {duplicated_element_name, scope})
+    }
+}
+
 
 // エントリーポイント
 struct LibEntry;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 // use gdnative::api::{Directory, File};
-use gdnative::prelude::*;
+use godot::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::fs::{File};
@@ -10,39 +10,47 @@ use image::error::{EncodingError, ImageFormatHint};
 use image::{ImageError, RgbaImage};
 use psd::{Psd, PsdGroup, PsdLayer};
 
-#[derive(NativeClass)]
-#[inherit(Node)]
+#[derive(GodotClass)]
+#[class(init, base = Node)]
 struct PsdDataExport {
-    #[property]
-    psd_dir: GodotString,
-    #[property]
-    export_dir: GodotString,
-    #[property]
+    #[export]
+    psd_dir: GString,
+    #[export]
+    export_dir: GString,
+    #[export]
     is_overwrite: bool,
-    #[property]
-    ignore_file_paths: gdnative::core_types::StringArray,
-    #[property]
-    image_extension: GodotString,
-    #[property]
+    #[export]
+    ignore_file_paths: godot::builtin::PackedStringArray, // godot::core_types::StringArray,
+    #[export]
+    image_extension: GString,
+    #[export]
     quality_factor: f32,
+
+    base: Base<Node>, 
 }
 
-#[methods]
-impl PsdDataExport {
-    fn new(_owner: &Node) -> Self {
-        PsdDataExport {
-            psd_dir: GodotString::from(""),
-            export_dir: GodotString::from(""),
-            is_overwrite: false,
-            ignore_file_paths: StringArray::new(),
-            image_extension: GodotString::from(""),
-            quality_factor: 0.0,
-        }
-    }
+// // NOTE: #[derive(GodotClass)] で #[class(init)] が指定されているとinit()を生成するため、これに加えて手動でinit()を書くと多重定義に陥る
+// #[godot_api]
+// impl INode for PsdDataExport{
+//     fn init(base: Base<Node>) -> Self {
+//         PsdDataExport {
+//             psd_dir: GString::from(""),
+//             export_dir: GString::from(""),
+//             is_overwrite: false,
+//             ignore_file_paths: PackedStringArray::new(),
+//             image_extension: GString::from(""),
+//             quality_factor: 0.0,
+//             base: base,
+//         }
+//     }
+// }
 
-    #[export]
-    fn execute(&self, _owner: &Node) {
-        let dir_path = GodotString::to_string(&self.psd_dir);
+#[godot_api]
+impl PsdDataExport {
+
+    #[func]
+    fn execute(&self) {
+        let dir_path = GString::to_string(&self.psd_dir);
         let mut psd_files: Vec<String> = Vec::new();
 
         // 再帰処理関数 ディレクトリ内のPSDファイル抽出
@@ -72,7 +80,7 @@ impl PsdDataExport {
 
                     let is_ignore = self.ignore_file_paths
                         .to_vec()
-                        .contains(&GodotString::from_str(psd_path.to_str().unwrap()));
+                        .contains(&GString::from(psd_path.to_str().unwrap()));
 
                     // godot_print!("is_ignore: {}",psd_path.to_str().unwrap());
                     // godot_print!("is_ignore: {}",is_ignore);
@@ -90,25 +98,27 @@ impl PsdDataExport {
     }
 
     fn export(&self, file_name: &str) {
-        let psd_dir_path = GodotString::to_string(&self.psd_dir);
+        godot_print!("{}", file_name);
+
+        let psd_dir_path = GString::to_string(&self.psd_dir);
         let psd_path = std::path::Path::new(&psd_dir_path);
         let psd_path = &psd_path.join(file_name.to_string() + ".psd");
         let bytes = fs::read(psd_path).unwrap();
-        let psd = Psd::from_bytes(&bytes).unwrap();
+        let psd = Psd::from_bytes(&bytes).unwrap(); // ここで落ちている？？
 
-        let export_dir_path = GodotString::to_string(&self.export_dir);
+        let export_dir_path = GString::to_string(&self.export_dir);
 
         let mut groups_json: Vec<Group> = Vec::new();
         let mut layers_json: Vec<Layer> = Vec::new();
 
-        let mut groups: Vec<&PsdGroup> = psd.group_ids_in_order()
+        let groups: Vec<&PsdGroup> = psd.group_ids_in_order()
             .iter()
             .map(|x| { psd.groups().get(x).unwrap() })
             .collect();
-        groups.sort_by_key(|x1| { x1.order_id() });
-        groups.sort_by_key(|x1| { x1.parent_id() });
+        // groups.sort_by_key(|x1| { x1.order_id() });
+        // groups.sort_by_key(|x1| { x1.parent_id() });
 
-        for group in groups.iter() {
+        for (i, group) in groups.iter().enumerate() {
             // println!("{}", i);
             // let (_, group) = psd.groups()
             //     .iter()
@@ -118,7 +128,7 @@ impl PsdDataExport {
             let group_model = Group {
                 id: group.id(),
                 parent_id: group.parent_id(),
-                visible: !group.visible(),
+                visible: group.visible(),
                 opacity: group.opacity(),
                 name: group.name().to_string(),
                 left: group.layer_left(),
@@ -128,18 +138,19 @@ impl PsdDataExport {
                 width: group.width(),
                 height: group.height(),
                 blending_mode: group.blend_mode() as u8,
-                order_id: group.order_id(),
+                // order_id: group.order_id(), // group.order_id() は存在しなくなっている
+                order_id: i32::try_from(i).unwrap(),
             };
             groups_json.push(group_model);
         }
-
-        let mut layers: Vec<&PsdLayer> = psd.layers()
+        
+        let layers: Vec<&PsdLayer> = psd.layers()
             .iter()
             .collect();
-        layers.sort_by_key(|x1| { x1.order_id() });
-        layers.sort_by_key(|x1| { x1.parent_id() });
+        // layers.sort_by_key(|x1| { x1.order_id() });
+        // layers.sort_by_key(|x1| { x1.parent_id() }); // レイヤーはpsdクレート側で既に表示順に並べられている
 
-        for layer in layers.iter() {
+        for (i, layer) in layers.iter().enumerate() {
             // println!("{}", layer.name());
             let layer_model = Layer {
                 parent_id: layer.parent_id(),
@@ -153,7 +164,8 @@ impl PsdDataExport {
                 width: layer.width(),
                 height: layer.height(),
                 blending_mode: layer.blend_mode() as u8,
-                order_id: layer.order_id(),
+                // order_id: layer.order_id(),
+                order_id: i32::try_from(i).unwrap(),
             };
             layers_json.push(layer_model);
         }
@@ -169,6 +181,13 @@ impl PsdDataExport {
         let layer_json_path = &export_dir_path.join("layers.json");
         fs::write(layer_json_path, serde_json::to_string(&layers_json).unwrap()).unwrap();
 
+        let doc_obj = PsdDoc {
+            psd_width: psd.width(),
+            psd_height: psd.height()
+        };
+        let doc_path = &export_dir_path.join("doc.json");
+        fs::write(doc_path, serde_json::to_string(&doc_obj).unwrap()).unwrap();
+
         // println!("{}", serde_json::to_string(&layers_json).unwrap());
 
         // println!("{}", "--------------------");
@@ -176,7 +195,7 @@ impl PsdDataExport {
         for layer in psd.layers().iter() {
             let layer_name: String = layer.name().to_string();
             let psd_width: u32 = psd.width();
-            let psd_height: u32 = psd.width();
+            let psd_height: u32 = psd.height();
             let layer_width: u32 = layer.width().into();
             let layer_height: u32 = layer.height().into();
             let layer_x: u32 = layer.layer_left() as u32;
@@ -185,8 +204,8 @@ impl PsdDataExport {
             let mut img = RgbaImage::from_raw(psd_width, psd_height, layer.rgba()).unwrap();
             // PSD全体からレイヤー部分のみクロップする
             let layer_image = image::imageops::crop(&mut img, layer_x, layer_y, layer_width, layer_height);
-            let extension = GodotString::to_string(&self.image_extension);
-            let export_image_path = &export_dir_path.join(layer_name + "." + GodotString::to_string(&self.image_extension).as_str());
+            let extension = GString::to_string(&self.image_extension);
+            let export_image_path = &export_dir_path.join(layer_name + "." + GString::to_string(&self.image_extension).as_str());
             match &*extension {
                 "png" => {
                     layer_image
@@ -268,18 +287,24 @@ pub fn init_panic_hook() {
 
         // unsafe {
         //     if let Some(gd_panic_hook) = gdnative::api::utils::autoload::<gdnative::api::Node>("rust_panic_hook") {
-        //         gd_panic_hook.call("rust_panic_hook", &[GodotString::from_str(error_message).to_variant()]);
+        //         gd_panic_hook.call("rust_panic_hook", &[GString::from_str(error_message).to_variant()]);
         //     }
         // }
     }));
 }
 
-fn init(handle: InitHandle) {
-    handle.add_tool_class::<PsdDataExport>();
-    init_panic_hook();
-}
+// fn init(handle: InitHandle) {
+//     handle.add_tool_class::<PsdDataExport>();
+//     init_panic_hook();
+// }
 
-godot_init!(init);
+// godot_init!(init);
+
+#[derive(Serialize, Deserialize, Debug)]
+struct PsdDoc {
+    psd_width : u32,
+    psd_height : u32
+}
 
 #[derive(Serialize, Deserialize, Debug)]
 struct Group {
@@ -313,4 +338,19 @@ struct Layer {
     height: u16,
     blending_mode: u8,
     order_id: i32,
+}
+
+// エントリーポイント
+struct LibEntry;
+
+#[gdextension]
+unsafe impl ExtensionLibrary for LibEntry {
+    fn min_level() -> InitLevel { InitLevel::Core }
+
+    fn on_level_init(level: InitLevel){
+        match level {
+            InitLevel::Core => {init_panic_hook()},
+            _ => {}
+        }
+    }
 }


### PR DESCRIPTION
・ファイル名の後ろに順序によって連番を付ける機能を追加した
  ・execute()に辞書型の引数を追加し、オプションを受け取れるようにした
  ・レイヤー名の重複を検査するようにした
    ・レイヤー名の重複があって正しく出力できないときはexportがエラーを返すようにした
    ・エラー用の構造体と必要なトレイトの実装をし、エラーがある場合にpush_errorするようにした
・gdextクレートのアップデートにより、Godot4.2向けにビルドする場合にフィーチャーフラグの指定が必要になったため、`features = ["api-4-2-2"]`を追加した